### PR TITLE
Transform inputs to comply with API specifications

### DIFF
--- a/src/Providers/nl_NL/PostcodeApiNu2.php
+++ b/src/Providers/nl_NL/PostcodeApiNu2.php
@@ -28,6 +28,8 @@ class PostcodeApiNu2 extends Provider {
      */
     public function find($postCode)
     {
+        $postCode = strtoupper(preg_replace('/\s+/', '', $postCode)); // P6 format (1234AB)
+
         $this->setRequestUrl(sprintf($this->getRequestUrl(), $postCode, ''));
         $response = $this->request();
 
@@ -52,6 +54,9 @@ class PostcodeApiNu2 extends Provider {
      */
     public function findByPostcodeAndHouseNumber($postCode, $houseNumber)
     {
+        $postCode = strtoupper(preg_replace('/\s+/', '', $postCode)); // P6 format (1234AB)
+        $houseNumber = preg_replace('/[^0-9.]/', '', $houseNumber); // Should be an integer
+
         $this->setRequestUrl(sprintf($this->getRequestUrl(), $postCode, $houseNumber));
         $response = $this->request();
 


### PR DESCRIPTION
The postcodeapi.nu API is really strict on the input values. Therefor I added a few lines to transform the inputs. (Strip spaces, make zip code uppercase and house number only numeric.)

I'm not sure if these changes will fit in your project conventions. It may be out of the scope of this project...
