### PR TITLE
Return object when there is no result

### DIFF
--- a/src/Providers/nl_NL/PostcodeApiNu2.php
+++ b/src/Providers/nl_NL/PostcodeApiNu2.php
@@ -32,6 +32,14 @@ class PostcodeApiNu2 extends Provider {
 
         $this->setRequestUrl(sprintf($this->getRequestUrl(), $postCode, ''));
         $response = $this->request();
+        
+        if(!isset($response['_embedded']['addresses'][0]))
+        {
+        	/**
+        	* Postcode / housnumber combination not found
+        	*/
+        	return new Address();
+        }
 
         $address = new Address();
         $address
@@ -59,6 +67,14 @@ class PostcodeApiNu2 extends Provider {
 
         $this->setRequestUrl(sprintf($this->getRequestUrl(), $postCode, $houseNumber));
         $response = $this->request();
+        
+        if(!isset($response['_embedded']['addresses'][0]))
+        {
+        	/**
+        	* Postcode / housnumber combination not found
+        	*/
+        	return new Address();
+        }
 
         $address = new Address();
         $address


### PR DESCRIPTION
An incorrect combination of postcode and housenumber resulted in a notice @ postcodeapiNu2. I made an edit: when there is an incorrect combination of postcode and housenumber, an empty Address object is returned.
