### PR TITLE
Change PHP version to match Laravel 5.8 requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["postcodeapi", "postcode", "api", "universal", "laravel"],
     "license": "MIT",
     "require": {
-        "php": "^7.2",
+        "php": "^7.1.3",
         "laravel/framework": "5.8.*",
         "guzzlehttp/guzzle": "6.*"
     },


### PR DESCRIPTION
The PHP version was upgraded in https://github.com/nickurt/laravel-postcodeapi/commit/5a481caec3be0194c48b4e0aaa0946a2dd46fbc4 to support Laravel 5.8, but L5.8 only requires PHP 7.1.3. Would it be possible to keep to 7.1.3 for now, to make upgrades easier (PHP 7.1 is still in security support; https://www.php.net/supported-versions.php )