### PR TITLE
Aliasing of providers

### DIFF
--- a/config/postcodeapi.php
+++ b/config/postcodeapi.php
@@ -32,6 +32,12 @@ return [
         'key' => '',
         'code' => 'nl_NL'
     ],
+    'PostcodeApiNuV3Sandbox' => [
+        'alias' => nickurt\PostcodeApi\Providers\nl_NL\PostcodeApiNuV3::class,
+        'url' => 'https://sandbox.postcodeapi.nu/v3/lookup/%s/%s',
+        'key' => '',
+        'code' => 'nl_NL'
+    ],
     'PostcodeData' => [
         'url' => 'http://api.postcodedata.nl/v1/postcode/?postcode=%s&streetnumber=%s&ref=%s',
         'key' => '',

--- a/config/postcodeapi.php
+++ b/config/postcodeapi.php
@@ -27,6 +27,11 @@ return [
         'key' => '',
         'code' => 'nl_NL',
     ],
+    'PostcodeApiNuV3' => [
+        'url' => 'https://api.postcodeapi.nu/v3/lookup/%s/%s',
+        'key' => '',
+        'code' => 'nl_NL'
+    ],
     'PostcodeData' => [
         'url' => 'http://api.postcodedata.nl/v1/postcode/?postcode=%s&streetnumber=%s&ref=%s',
         'key' => '',

--- a/src/ProviderFactory.php
+++ b/src/ProviderFactory.php
@@ -19,7 +19,8 @@ class ProviderFactory
         }
 
         /** @var Provider $class */
-        if (class_exists($providerClass = 'nickurt\\PostcodeApi\\Providers\\' . $config['code'] . '\\' . $provider)) {
+        $providerClass = !empty($config['alias']) ? $config['alias'] : "nickurt\\PostcodeApi\\Providers\\{$config['code']}\\{$provider}";
+        if (class_exists($providerClass)) {
             $class = (new $providerClass);
             $class->setApiKey($config['key']);
             $class->setRequestUrl($config['url']);

--- a/src/Providers/nl_NL/PostcodeApiNuV3.php
+++ b/src/Providers/nl_NL/PostcodeApiNuV3.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace nickurt\postcodeapi\Providers\nl_NL;
+
+use Illuminate\Support\Arr;
+use nickurt\PostcodeApi\Entity\Address;
+use nickurt\PostcodeApi\Exception\NotSupportedException;
+use nickurt\PostcodeApi\Providers\Provider;
+
+class PostcodeApiNuV3 extends Provider
+{
+    /**
+     * @param string $postCode
+     * @return Address
+     */
+    public function find($postCode)
+    {
+        throw new NotSupportedException('Cannot search with postcode only');
+    }
+
+    protected function request()
+    {
+        $response = $this->getHttpClient()->request('GET', $this->getRequestUrl(), [
+            'headers' => [
+                'X-Api-Key' => $this->getApiKey()
+            ]
+        ]);
+
+        return json_decode($response->getBody(), true);
+    }
+
+    /**
+     * @param string $postCode
+     * @return Address
+     */
+    public function findByPostcode($postCode)
+    {
+        return $this->find($postCode);
+    }
+
+    /**
+     * @param string $postCode
+     * @param string $houseNumber
+     * @return Address
+     */
+    public function findByPostcodeAndHouseNumber($postCode, $houseNumber)
+    {
+        // Format postcode into 1234AB format
+        $postCode = strtoupper(preg_replace('/\s+/', '', $postCode));
+
+        // Extract number from house number
+        $houseNumber = preg_replace('/^\s*(\d+).*$/', '\1', $houseNumber);
+
+        // Send request
+        $this->setRequestUrl(sprintf($this->getRequestUrl(), $postCode, $houseNumber));
+
+        // Handle response
+        $response = $this->request();
+
+        // Check for a street
+        if (!Arr::has($response, 'street')) {
+            // Postcode / housenumber combination not found
+            return new Address();
+        }
+
+        // Found it :)
+        return (new Address())
+            ->setStreet(Arr::get($response, 'street'))
+            ->setHouseNo((string) Arr::get($response, 'number'))
+            ->setTown(Arr::get($response, 'city'))
+            ->setMunicipality(Arr::get($response, 'municipality'))
+            ->setProvince(Arr::get($response, 'province'))
+            // They're [long, lat]!
+            ->setLongitude(Arr::get($response, 'location.coordinates.0'))
+            ->setLatitude(Arr::get($response, 'location.coordinates.1'));
+    }
+}

--- a/tests/PostcodeApiTest.php
+++ b/tests/PostcodeApiTest.php
@@ -46,4 +46,11 @@ class PostcodeApiTest extends TestCase
     {
         $this->assertInstanceOf(\GuzzleHttp\Client::class, PostcodeApi::create('NationaalGeoRegister')->getHttpClient());
     }
+
+    /** @test */
+    public function it_can_create_a_new_provider_with_alias_via_helper_function()
+    {
+        $this->assertInstanceOf(\nickurt\postcodeapi\Providers\nl_NL\PostcodeApiNuV3::class, postcodeapi('PostcodeApiNuV3Sandbox'));
+    }
+
 }

--- a/tests/Providers/nl_NL/PostcodeApiNuV3Test.php
+++ b/tests/Providers/nl_NL/PostcodeApiNuV3Test.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace nickurt\PostcodeApi\tests\Providers\nl_NL;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use nickurt\PostcodeApi\Entity\Address;
+use nickurt\PostcodeApi\Exception\NotSupportedException;
+use nickurt\PostcodeApi\Providers\nl_NL\PostcodeApiNuV3;
+use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+
+class PostcodeApiNuV3Test extends BaseProviderTest
+{
+    const TEST_URL = 'https://sandbox.postcodeapi.nu/v3/lookup/%s/%s';
+    const TEST_APIKEY = '00e97e79-63a8-4497-a5de-47ca2cbba64f';
+
+    /** @var PostcodeApiNu */
+    protected $postcodeApiNu;
+
+    public function setUp(): void
+    {
+        $this->postcodeApiNu = (new PostcodeApiNuV3())
+            ->setRequestUrl(self::TEST_URL)
+            ->setApiKey(self::TEST_APIKEY);
+    }
+
+    /** @test */
+    public function it_can_get_the_default_config_values_for_this_provider()
+    {
+        $this->assertSame(self::TEST_URL, $this->postcodeApiNu->getRequestUrl());
+        $this->assertSame(self::TEST_APIKEY, $this->postcodeApiNu->getApiKey());
+    }
+
+    /** @test */
+    public function it_throws_exception_for_find_postal_code()
+    {
+        $this->expectException(NotSupportedException::class);
+        $this->postcodeApiNu->find('6545CA');
+    }
+
+
+    /** @test */
+    public function it_can_get_the_correct_values_for_find_by_postcode_and_house_number_a_valid_postal_code()
+    {
+        $address = $this->postcodeApiNu->setHttpClient(new Client([
+            'handler' => new MockHandler([
+                new Response(200, [], '{"postcode":"6545CA","number":29,"street":"Waldeck Pyrmontsingel","city":"Nijmegen","municipality":"Nijmegen","province":"Gelderland","location":{"type":"Point","coordinates":[5.8696099,51.841554]}}')
+            ]),
+        ]))->findByPostcodeAndHouseNumber('6545CA', '29');
+
+        $this->assertSame(self::TEST_APIKEY, $this->postcodeApiNu->getApiKey());
+        $this->assertSame(sprintf(self::TEST_URL, '6545CA', '29'), $this->postcodeApiNu->getRequestUrl());
+
+        $this->assertInstanceOf(Address::class, $address);
+
+        $this->assertSame([
+            'street' => 'Waldeck Pyrmontsingel',
+            'house_no' => '29',
+            'town' => 'Nijmegen',
+            'municipality' => 'Nijmegen',
+            'province' => 'Gelderland',
+            'latitude' => 51.841554,
+            'longitude' => 5.8696099,
+        ], $address->toArray());
+    }
+
+    /** @test */
+    public function it_can_get_the_correct_values_for_find_by_postcode_and_house_number_an_invalid_postal_code()
+    {
+        $address = $this->postcodeApiNu->setHttpClient(new Client([
+            'handler' => new MockHandler([
+                new Response(404, [], '{"title":"Resource not found"}')
+            ]),
+        ]))->findByPostcodeAndHouseNumber('6545CA', '299');
+
+        $this->assertInstanceOf(Address::class, $address);
+
+        $this->assertSame([
+            'street' => null,
+            'house_no' => null,
+            'town' => null,
+            'municipality' => null,
+            'province' => null,
+            'latitude' => null,
+            'longitude' => null
+        ], $address->toArray());
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,6 +21,12 @@ class TestCase extends Orchestra
                 'key' => '',
                 'code' => 'nl_NL'
             ],
+            'PostcodeApiNuV3Sandbox' => [
+                'alias' => 'nickurt\\PostcodeApi\\Providers\\nl_NL\\PostcodeApiNuV3',
+                'url' => 'https://sandbox.postcodeapi.nu/v3/lookup/%s/%s',
+                'key' => '',
+                'code' => 'nl_NL'
+            ],
         ]);
     }
 


### PR DESCRIPTION
Add support for an `alias` property on a provider, allowing you to use sandboxes, or a `default` property to link to a Postcode API provider.

See #17 