### PR TITLE
Fix authoritative autoloader issues

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -42,3 +42,8 @@ jobs:
 
             -   name: Execute tests
                 run: vendor/bin/phpunit
+
+            -   name: Execute tests with frozen classmap
+                run: |
+                    composer dump-autoload --classmap-authoritative
+                    vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "nickurt\\PostcodeApi\\tests\\": "tests"
+      "nickurt\\PostcodeApi\\Tests\\": "tests"
     }
   },
   "minimum-stability": "dev",

--- a/src/Providers/en_AU/PostcodeApiComAu.php
+++ b/src/Providers/en_AU/PostcodeApiComAu.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\en_AU;
+namespace nickurt\PostcodeApi\Providers\en_AU;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;

--- a/src/Providers/en_GB/GeoPostcodeOrgUk.php
+++ b/src/Providers/en_GB/GeoPostcodeOrgUk.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\en_GB;
+namespace nickurt\PostcodeApi\Providers\en_GB;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;

--- a/src/Providers/en_GB/GetAddressIO.php
+++ b/src/Providers/en_GB/GetAddressIO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\en_GB;
+namespace nickurt\PostcodeApi\Providers\en_GB;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\Provider;

--- a/src/Providers/en_GB/IdealPostcodes.php
+++ b/src/Providers/en_GB/IdealPostcodes.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\en_GB;
+namespace nickurt\PostcodeApi\Providers\en_GB;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\Provider;

--- a/src/Providers/en_GB/PostcodesIO.php
+++ b/src/Providers/en_GB/PostcodesIO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\en_GB;
+namespace nickurt\PostcodeApi\Providers\en_GB;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\Provider;

--- a/src/Providers/en_GB/UkPostcodes.php
+++ b/src/Providers/en_GB/UkPostcodes.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\en_GB;
+namespace nickurt\PostcodeApi\Providers\en_GB;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\Provider;

--- a/src/Providers/en_US/Algolia.php
+++ b/src/Providers/en_US/Algolia.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\en_US;
+namespace nickurt\PostcodeApi\Providers\en_US;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\Provider;

--- a/src/Providers/en_US/Bing.php
+++ b/src/Providers/en_US/Bing.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\en_US;
+namespace nickurt\PostcodeApi\Providers\en_US;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\Provider;

--- a/src/Providers/en_US/Geocodio.php
+++ b/src/Providers/en_US/Geocodio.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\en_US;
+namespace nickurt\PostcodeApi\Providers\en_US;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\Provider;

--- a/src/Providers/en_US/Google.php
+++ b/src/Providers/en_US/Google.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\en_US;
+namespace nickurt\PostcodeApi\Providers\en_US;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\Provider;

--- a/src/Providers/en_US/Here.php
+++ b/src/Providers/en_US/Here.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\en_US;
+namespace nickurt\PostcodeApi\Providers\en_US;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\Provider;

--- a/src/Providers/en_US/LocationIQ.php
+++ b/src/Providers/en_US/LocationIQ.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\en_US;
+namespace nickurt\PostcodeApi\Providers\en_US;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\Provider;

--- a/src/Providers/en_US/Mapbox.php
+++ b/src/Providers/en_US/Mapbox.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\en_US;
+namespace nickurt\PostcodeApi\Providers\en_US;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;

--- a/src/Providers/en_US/OpenCage.php
+++ b/src/Providers/en_US/OpenCage.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\en_US;
+namespace nickurt\PostcodeApi\Providers\en_US;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\Provider;

--- a/src/Providers/en_US/TomTom.php
+++ b/src/Providers/en_US/TomTom.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\en_US;
+namespace nickurt\PostcodeApi\Providers\en_US;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;

--- a/src/Providers/fr_FR/AddresseDataGouv.php
+++ b/src/Providers/fr_FR/AddresseDataGouv.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\fr_FR;
+namespace nickurt\PostcodeApi\Providers\fr_FR;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\Provider;

--- a/src/Providers/nl_BE/Pro6PP_BE.php
+++ b/src/Providers/nl_BE/Pro6PP_BE.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\nl_BE;
+namespace nickurt\PostcodeApi\Providers\nl_BE;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\Provider;

--- a/src/Providers/nl_NL/ApiPostcode.php
+++ b/src/Providers/nl_NL/ApiPostcode.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\nl_NL;
+namespace nickurt\PostcodeApi\Providers\nl_NL;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\Provider;

--- a/src/Providers/nl_NL/NationaalGeoRegister.php
+++ b/src/Providers/nl_NL/NationaalGeoRegister.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\nl_NL;
+namespace nickurt\PostcodeApi\Providers\nl_NL;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\Provider;

--- a/src/Providers/nl_NL/PostcoDe.php
+++ b/src/Providers/nl_NL/PostcoDe.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\nl_NL;
+namespace nickurt\PostcodeApi\Providers\nl_NL;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;

--- a/src/Providers/nl_NL/PostcodeApiNu.php
+++ b/src/Providers/nl_NL/PostcodeApiNu.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\nl_NL;
+namespace nickurt\PostcodeApi\Providers\nl_NL;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\Provider;

--- a/src/Providers/nl_NL/PostcodeApiNuV3.php
+++ b/src/Providers/nl_NL/PostcodeApiNuV3.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\nl_NL;
+namespace nickurt\PostcodeApi\Providers\nl_NL;
 
 use Illuminate\Support\Arr;
 use nickurt\PostcodeApi\Entity\Address;

--- a/src/Providers/nl_NL/PostcodeData.php
+++ b/src/Providers/nl_NL/PostcodeData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\nl_NL;
+namespace nickurt\PostcodeApi\Providers\nl_NL;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\Provider;

--- a/src/Providers/nl_NL/PostcodeNL.php
+++ b/src/Providers/nl_NL/PostcodeNL.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\nl_NL;
+namespace nickurt\PostcodeApi\Providers\nl_NL;
 
 use \nickurt\PostcodeApi\Providers\Provider;
 use \nickurt\PostcodeApi\Entity\Address;

--- a/src/Providers/nl_NL/PostcodesNL.php
+++ b/src/Providers/nl_NL/PostcodesNL.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\nl_NL;
+namespace nickurt\PostcodeApi\Providers\nl_NL;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\Provider;

--- a/src/Providers/nl_NL/Pro6PP_NL.php
+++ b/src/Providers/nl_NL/Pro6PP_NL.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\nl_NL;
+namespace nickurt\PostcodeApi\Providers\nl_NL;
 
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\Provider;

--- a/src/Providers/nl_NL/Pstcd.php
+++ b/src/Providers/nl_NL/Pstcd.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\postcodeapi\Providers\nl_NL;
+namespace nickurt\PostcodeApi\Providers\nl_NL;
 
 use \nickurt\PostcodeApi\Providers\Provider;
 use \nickurt\PostcodeApi\Entity\Address;

--- a/tests/Entity/AddressTest.php
+++ b/tests/Entity/AddressTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Entity;
+namespace nickurt\PostcodeApi\Tests\Entity;
 
 use nickurt\PostcodeApi\Entity\Address;
 use PHPUnit\Framework\TestCase;

--- a/tests/PostcodeApiTest.php
+++ b/tests/PostcodeApiTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests;
+namespace nickurt\PostcodeApi\Tests;
 
 use nickurt\PostcodeApi\ProviderFactory as PostcodeApi;
 
@@ -9,7 +9,7 @@ class PostcodeApiTest extends TestCase
     /** @test */
     public function it_can_create_a_new_provider_via_helper_function()
     {
-        $this->assertInstanceOf(\nickurt\postcodeapi\Providers\nl_NL\NationaalGeoRegister::class, postcodeapi('NationaalGeoRegister'));
+        $this->assertInstanceOf(\nickurt\PostcodeApi\Providers\nl_NL\NationaalGeoRegister::class, postcodeapi('NationaalGeoRegister'));
     }
 
     /** @test */
@@ -44,8 +44,8 @@ class PostcodeApiTest extends TestCase
         /** @var \nickurt\PostcodeApi\Providers\nl_NL\NationaalGeoRegister $nationaalGeoRegister */
         $nationaalGeoRegister = PostcodeApi::create('NationaalGeoRegister');
 
-        $this->assertInstanceOf(\nickurt\postcodeapi\Providers\Provider::class, $nationaalGeoRegister);
-        $this->assertInstanceOf(\nickurt\postcodeapi\Providers\nl_NL\NationaalGeoRegister::class, $nationaalGeoRegister);
+        $this->assertInstanceOf(\nickurt\PostcodeApi\Providers\Provider::class, $nationaalGeoRegister);
+        $this->assertInstanceOf(\nickurt\PostcodeApi\Providers\nl_NL\NationaalGeoRegister::class, $nationaalGeoRegister);
 
         $this->assertSame(['foo' => 'bar'], $nationaalGeoRegister->getOptions());
         $this->assertSame('key', $nationaalGeoRegister->getApiKey());
@@ -62,7 +62,7 @@ class PostcodeApiTest extends TestCase
     /** @test */
     public function it_can_create_a_new_provider_with_alias_via_helper_function()
     {
-        $this->assertInstanceOf(\nickurt\postcodeapi\Providers\nl_NL\PostcodeApiNuV3::class, postcodeapi('PostcodeApiNuV3Sandbox'));
+        $this->assertInstanceOf(\nickurt\PostcodeApi\Providers\nl_NL\PostcodeApiNuV3::class, postcodeapi('PostcodeApiNuV3Sandbox'));
     }
 
 }

--- a/tests/Providers/BaseProviderTest.php
+++ b/tests/Providers/BaseProviderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers;
+namespace nickurt\PostcodeApi\Tests\Providers;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Providers/en_AU/PostcodeApiComAuTest.php
+++ b/tests/Providers/en_AU/PostcodeApiComAuTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\en_AU;
+namespace nickurt\PostcodeApi\Tests\Providers\en_AU;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
@@ -8,7 +8,7 @@ use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;
 use nickurt\PostcodeApi\Providers\en_AU\PostcodeApiComAu;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class PostcodeApiComAuTest extends BaseProviderTest
 {

--- a/tests/Providers/en_GB/GeoPostcodeOrgUkTest.php
+++ b/tests/Providers/en_GB/GeoPostcodeOrgUkTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\en_GB;
+namespace nickurt\PostcodeApi\Tests\Providers\en_GB;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
@@ -8,9 +8,9 @@ use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;
 use nickurt\PostcodeApi\Providers\en_GB\GeoPostcodeOrgUk;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
-class GeoPostcodeOrkUkTest extends BaseProviderTest
+class GeoPostcodeOrgUkTest extends BaseProviderTest
 {
     /** @var GeoPostcodeOrgUk */
     protected $geoPostcodeOrgUk;

--- a/tests/Providers/en_GB/GetAddressIOTest.php
+++ b/tests/Providers/en_GB/GetAddressIOTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\en_GB;
+namespace nickurt\PostcodeApi\Tests\Providers\en_GB;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\en_GB\GetAddressIO;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class GetAddressIOTest extends BaseProviderTest
 {

--- a/tests/Providers/en_GB/IdealPostcodesTest.php
+++ b/tests/Providers/en_GB/IdealPostcodesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\en_GB;
+namespace nickurt\PostcodeApi\Tests\Providers\en_GB;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
@@ -8,7 +8,7 @@ use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;
 use nickurt\PostcodeApi\Providers\en_GB\IdealPostcodes;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class IdealPostcodesTest extends BaseProviderTest
 {

--- a/tests/Providers/en_GB/PostcodesIOTest.php
+++ b/tests/Providers/en_GB/PostcodesIOTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\en_GB;
+namespace nickurt\PostcodeApi\Tests\Providers\en_GB;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
@@ -8,7 +8,7 @@ use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;
 use nickurt\PostcodeApi\Providers\en_GB\PostcodesIO;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class PostcodesIOTest extends BaseProviderTest
 {

--- a/tests/Providers/en_GB/UkPostcodesTest.php
+++ b/tests/Providers/en_GB/UkPostcodesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\en_GB;
+namespace nickurt\PostcodeApi\Tests\Providers\en_GB;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
@@ -8,7 +8,7 @@ use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;
 use nickurt\PostcodeApi\Providers\en_GB\UkPostcodes;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class UkPostcodesTest extends BaseProviderTest
 {

--- a/tests/Providers/en_US/AlgoliaTest.php
+++ b/tests/Providers/en_US/AlgoliaTest.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\en_US;
+namespace nickurt\PostcodeApi\Tests\Providers\en_US;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class AlgoliaTest extends BaseProviderTest
 {
-    /** @var \nickurt\postcodeapi\Providers\en_US\Algolia */
+    /** @var \nickurt\PostcodeApi\Providers\en_US\Algolia */
     protected $algolia;
 
     public function setUp(): void

--- a/tests/Providers/en_US/BingTest.php
+++ b/tests/Providers/en_US/BingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\en_US;
+namespace nickurt\PostcodeApi\Tests\Providers\en_US;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
@@ -8,7 +8,7 @@ use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;
 use nickurt\PostcodeApi\Providers\en_US\Bing;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class BingTest extends BaseProviderTest
 {

--- a/tests/Providers/en_US/GeocodioTest.php
+++ b/tests/Providers/en_US/GeocodioTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\en_US;
+namespace nickurt\PostcodeApi\Tests\Providers\en_US;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
@@ -8,7 +8,7 @@ use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;
 use nickurt\PostcodeApi\Providers\en_US\Geocodio;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class GeocodioTest extends BaseProviderTest
 {

--- a/tests/Providers/en_US/GoogleTest.php
+++ b/tests/Providers/en_US/GoogleTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\en_US;
+namespace nickurt\PostcodeApi\Tests\Providers\en_US;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\en_US\Google;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class GoogleTest extends BaseProviderTest
 {

--- a/tests/Providers/en_US/HereTest.php
+++ b/tests/Providers/en_US/HereTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\en_US;
+namespace nickurt\PostcodeApi\Tests\Providers\en_US;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
@@ -8,7 +8,7 @@ use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;
 use nickurt\PostcodeApi\Providers\en_US\Here;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class HereTest extends BaseProviderTest
 {

--- a/tests/Providers/en_US/LocationIQTest.php
+++ b/tests/Providers/en_US/LocationIQTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\en_US;
+namespace nickurt\PostcodeApi\Tests\Providers\en_US;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class LocationIQTest extends BaseProviderTest
 {

--- a/tests/Providers/en_US/MapboxTest.php
+++ b/tests/Providers/en_US/MapboxTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\en_US;
+namespace nickurt\PostcodeApi\Tests\Providers\en_US;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class MapboxTest extends BaseProviderTest
 {

--- a/tests/Providers/en_US/OpenCageTest.php
+++ b/tests/Providers/en_US/OpenCageTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\en_US;
+namespace nickurt\PostcodeApi\Tests\Providers\en_US;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
@@ -8,7 +8,7 @@ use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;
 use nickurt\PostcodeApi\Providers\en_US\OpenCage;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class OpenCageTest extends BaseProviderTest
 {

--- a/tests/Providers/en_US/TomTomTest.php
+++ b/tests/Providers/en_US/TomTomTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\en_US;
+namespace nickurt\PostcodeApi\Tests\Providers\en_US;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class TomTomTest extends BaseProviderTest
 {

--- a/tests/Providers/fr_FR/AdresseDataGouvTest.php
+++ b/tests/Providers/fr_FR/AdresseDataGouvTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\fr_FR;
+namespace nickurt\PostcodeApi\Tests\Providers\fr_FR;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\fr_FR\AddresseDataGouv;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class AdresseDataGouvTest extends BaseProviderTest
 {

--- a/tests/Providers/nl_BE/Pro6PP_BETest.php
+++ b/tests/Providers/nl_BE/Pro6PP_BETest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\nl_BE;
+namespace nickurt\PostcodeApi\Tests\Providers\nl_BE;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
@@ -8,7 +8,7 @@ use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;
 use nickurt\PostcodeApi\Providers\nl_BE\Pro6PP_BE;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class Pro6PP_BETest extends BaseProviderTest
 {

--- a/tests/Providers/nl_NL/ApiPostcodeTest.php
+++ b/tests/Providers/nl_NL/ApiPostcodeTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\nl_NL;
+namespace nickurt\PostcodeApi\Tests\Providers\nl_NL;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\nl_NL\ApiPostcode;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class ApiPostcodeTest extends BaseProviderTest
 {

--- a/tests/Providers/nl_NL/NationaalGeoRegisterTest.php
+++ b/tests/Providers/nl_NL/NationaalGeoRegisterTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\nl_NL;
+namespace nickurt\PostcodeApi\Tests\Providers\nl_NL;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\nl_NL\NationaalGeoRegister;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class NationaalGeoRegisterTest extends BaseProviderTest
 {

--- a/tests/Providers/nl_NL/PostcoDeTest.php
+++ b/tests/Providers/nl_NL/PostcoDeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\nl_NL;
+namespace nickurt\PostcodeApi\Tests\Providers\nl_NL;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
@@ -8,7 +8,7 @@ use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;
 use nickurt\PostcodeApi\Providers\nl_NL\PostcoDe;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class PostcoDeTest extends BaseProviderTest
 {

--- a/tests/Providers/nl_NL/PostcodeApiNuTest.php
+++ b/tests/Providers/nl_NL/PostcodeApiNuTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\nl_NL;
+namespace nickurt\PostcodeApi\Tests\Providers\nl_NL;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\nl_NL\PostcodeApiNu;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class PostcodeApiNuTest extends BaseProviderTest
 {

--- a/tests/Providers/nl_NL/PostcodeApiNuV3Test.php
+++ b/tests/Providers/nl_NL/PostcodeApiNuV3Test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\nl_NL;
+namespace nickurt\PostcodeApi\Tests\Providers\nl_NL;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
@@ -8,7 +8,7 @@ use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;
 use nickurt\PostcodeApi\Providers\nl_NL\PostcodeApiNuV3;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class PostcodeApiNuV3Test extends BaseProviderTest
 {

--- a/tests/Providers/nl_NL/PostcodeDataTest.php
+++ b/tests/Providers/nl_NL/PostcodeDataTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\nl_NL;
+namespace nickurt\PostcodeApi\Tests\Providers\nl_NL;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
@@ -8,7 +8,7 @@ use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Exception\NotSupportedException;
 use nickurt\PostcodeApi\Providers\nl_NL\PostcodeData;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class PostcodeDataTest extends BaseProviderTest
 {

--- a/tests/Providers/nl_NL/PostcodesNLTest.php
+++ b/tests/Providers/nl_NL/PostcodesNLTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\nl_NL;
+namespace nickurt\PostcodeApi\Tests\Providers\nl_NL;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\nl_NL\PostcodesNL;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class PostcodesNLTest extends BaseProviderTest
 {

--- a/tests/Providers/nl_NL/Pro6PP_NLTest.php
+++ b/tests/Providers/nl_NL/Pro6PP_NLTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests\Providers\nl_NL;
+namespace nickurt\PostcodeApi\Tests\Providers\nl_NL;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use nickurt\PostcodeApi\Entity\Address;
 use nickurt\PostcodeApi\Providers\nl_NL\Pro6PP_NL;
-use nickurt\PostcodeApi\tests\Providers\BaseProviderTest;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
 
 class Pro6PP_NLTest extends BaseProviderTest
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace nickurt\PostcodeApi\tests;
+namespace nickurt\PostcodeApi\Tests;
 
 use Orchestra\Testbench\TestCase as Orchestra;
 


### PR DESCRIPTION
This solves the authoritative mode of Composer not loading some classes

- **all providers are affected**
- This also runs the unit tests with an optimized, authoritative classmap, to check if it actually works (it'll explode if it's wrongly registered again)
- Also moved the tests from the `nickurt\PostcodeApi\tests` namespace to the `nickurt\PostcodeApi\Tests` namespace, to be more in line with PSR-4.

Fixes #19.