### PR TITLE
Change visibility of find methods in Provider class

### DIFF
--- a/src/Providers/Provider.php
+++ b/src/Providers/Provider.php
@@ -132,24 +132,24 @@ abstract class Provider implements ProviderInterface
     /**
      * @return mixed
      */
-    abstract protected function request();
+    abstract public function request();
 
     /**
      * @param string $postCode
      * @return Address
      */
-    abstract protected function find($postCode);
+    abstract public function find($postCode);
 
     /**
      * @param string $postCode
      * @return Address
      */
-    abstract protected function findByPostcode($postCode);
+    abstract public function findByPostcode($postCode);
 
     /**
      * @param string $postCode
      * @param string $houseNumber
      * @return Address
      */
-    abstract protected function findByPostcodeAndHouseNumber($postCode, $houseNumber);
+    abstract public function findByPostcodeAndHouseNumber($postCode, $houseNumber);
 }

--- a/src/Providers/Provider.php
+++ b/src/Providers/Provider.php
@@ -130,11 +130,6 @@ abstract class Provider implements ProviderInterface
     }
 
     /**
-     * @return mixed
-     */
-    abstract public function request();
-
-    /**
      * @param string $postCode
      * @return Address
      */
@@ -152,4 +147,9 @@ abstract class Provider implements ProviderInterface
      * @return Address
      */
     abstract public function findByPostcodeAndHouseNumber($postCode, $houseNumber);
+
+    /**
+     * @return mixed
+     */
+    abstract protected function request();
 }


### PR DESCRIPTION
If you look at your examples, all `find()` methods are publicly accessible, so we need to change the visible to `public` instead of `protected`.