### PR TITLE
Added 2 Providers for Germany

### DIFF
--- a/config/postcodeapi.php
+++ b/config/postcodeapi.php
@@ -149,5 +149,15 @@ return [
         'url' => 'https://api-adresse.data.gouv.fr/search/?q=%s&postcode=%s&limit=1',
         'key' => '',
         'code' => 'fr_FR'
+    ],
+   'GeonamesDE' => [
+        'url' => 'http://api.geonames.org/postalCodeLookupJSON?postalcode=%s&country=DE&username=demo',
+        'key' => '',
+        'code' => 'de_DE'
+    ],
+   'ZippopotamusDE' => [
+        'url' => 'http://api.zippopotam.us/DE/%s',
+        'key' => '',
+        'code' => 'de_DE'
     ]
 ];

--- a/src/Providers/de_DE/GeonamesDE.php
+++ b/src/Providers/de_DE/GeonamesDE.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace nickurt\PostcodeApi\Providers\de_DE;
+
+use nickurt\PostcodeApi\Entity\Address;
+use nickurt\PostcodeApi\Providers\Provider;
+
+class GeonamesDE extends Provider
+{
+    /**
+     * @param string $postCode
+     * @return Address
+     */
+    public function find($postCode)
+    {
+        $this->setRequestUrl(sprintf($this->getRequestUrl(), $postCode, ''));
+
+        $response = $this->request();
+
+        if (count($response['postalcodes']) < 1) {
+            return new Address();
+        }
+
+        $address = new Address();
+        $address
+            ->setTown($response['postalcodes'][0]['placeName'])
+            ->setMunicipality($response['postalcodes'][0]['adminName3'])
+            ->setProvince($response['postalcodes'][0]['adminName1'])
+            ->setLatitude($response['postalcodes'][0]['lat'])
+            ->setLongitude($response['postalcodes'][0]['lng']);
+
+        return $address;
+    }
+
+    protected function request()
+    {
+        $response = $this->getHttpClient()->request('GET', $this->getRequestUrl());
+
+        return json_decode($response->getBody(), true);
+    }
+
+    /**
+     * @param string $postCode
+     * @return Address
+     */
+    public function findByPostcode($postCode)
+    {
+        return $this->find($postCode);
+    }
+
+    /**
+     * @param string $postCode
+     * @param string $houseNumber
+     * @return Address
+     */
+    public function findByPostcodeAndHouseNumber($postCode, $houseNumber)
+    {
+        $this->setRequestUrl( sprintf( $this->getRequestUrl(), $postCode . '&placename=' . $houseNumber, '') );
+
+        $response = $this->request();
+
+        if (count($response['postalcodes']) < 1) {
+            return new Address();
+        }
+
+        $address = new Address();
+        $address
+            ->setTown($response['postalcodes'][0]['placeName'])
+            ->setMunicipality($response['postalcodes'][0]['adminName3'])
+            ->setProvince($response['postalcodes'][0]['adminName1'])
+            ->setLatitude($response['postalcodes'][0]['lat'])
+            ->setLongitude($response['postalcodes'][0]['lng']);
+
+        return $address;
+    }
+
+}

--- a/src/Providers/de_DE/ZippopotamusDE.php
+++ b/src/Providers/de_DE/ZippopotamusDE.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace nickurt\PostcodeApi\Providers\de_DE;
+
+use nickurt\PostcodeApi\Entity\Address;
+use nickurt\PostcodeApi\Providers\Provider;
+
+class ZippopotamusDE extends Provider
+{
+    /**
+     * @param string $postCode
+     * @return Address
+     */
+    public function find($postCode)
+    {
+        $this->setRequestUrl(sprintf($this->getRequestUrl(), $postCode, ''));
+
+        $response = $this->request();
+
+        if (isset($response['places']) < 1) {
+            return new Address();
+        }
+
+        $address = new Address();
+        $address
+            ->setTown($response['places'][0]['place name'])
+            ->setProvince($response['places'][0]['state'])
+            ->setLatitude($response['places'][0]['latitude'])
+            ->setLongitude($response['places'][0]['longitude']);
+
+        return $address;
+    }
+
+    protected function request()
+    {
+        $response = $this->getHttpClient()->request('GET', $this->getRequestUrl());
+
+        return json_decode($response->getBody(), true);
+    }
+
+    /**
+     * @param string $postCode
+     * @return Address
+     */
+    public function findByPostcode($postCode)
+    {
+        return $this->find($postCode);
+    }
+
+    /**
+     * @param string $postCode
+     * @param string $houseNumber
+     * @return PostCodeApi\Exception
+     */
+    public function findByPostcodeAndHouseNumber($postCode, $houseNumber)
+    {
+        throw new \nickurt\PostcodeApi\Exception\NotSupportedException();
+    }
+
+}

--- a/tests/Providers/de_DE/GeonamesDE.php
+++ b/tests/Providers/de_DE/GeonamesDE.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace nickurt\PostcodeApi\Tests\Providers\de_DE;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use nickurt\PostcodeApi\Entity\Address;
+use nickurt\PostcodeApi\Exception\NotSupportedException;
+use nickurt\PostcodeApi\Providers\de_DE\GeonamesDE;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
+
+class GeonamesDETest extends BaseProviderTest
+{
+    /** @var geonames */
+    protected $geonames;
+
+    public function setUp(): void
+    {
+        $this->geonames = (new GeonamesDE)
+            ->setRequestUrl('https://api.geonames.org/postalCodeLookupJSON?postalcode=%s&country=DE&username=demo')
+            ->setApiKey('');
+    }
+
+    /** @test */
+    public function it_can_get_the_default_config_values_for_this_provider()
+    {
+        $this->assertSame('', $this->geonames->getApiKey());
+        $this->assertSame('https://api.geonames.org/postalCodeLookupJSON?postalcode=%s&country=DE&username=demo', $this->geonames->getRequestUrl());
+    }
+
+    /** @test */
+    public function it_can_get_the_correct_values_for_find_a_valid_postal_code()
+    {
+        $address = $this->geonames->setHttpClient(new Client([
+            'handler' => new MockHandler([
+                new Response(200, [], '{"postalcodes":[{"adminCode2":"00","adminCode3":"16074","adminName3":"Saale-Holzland-Kreis","adminCode1":"TH","lng":11.5166667,"countryCode":"DE","postalCode":"07751","adminName1":"Thüringen","ISO3166-2":"TH","placeName":"Bucha","lat":50.8833333}]}')
+            ]),
+        ]))->find('07751');
+
+        $this->assertSame('', $this->geonames->getApiKey());
+        $this->assertSame('https://api.geonames.org/postalCodeLookupJSON?postalcode=07751&country=DE&username=demo', $this->geonames->getRequestUrl());
+
+        $this->assertInstanceOf(Address::class, $address);
+
+        $this->assertSame([
+            'street' => null,
+            'house_no' => null,
+            'town' => 'Bucha',
+            'municipality' => 'Saale-Holzland-Kreis',
+            'province' => 'Thüringen',
+            'latitude' => 50.8833333,
+            'longitude' => 11.5166667
+        ], $address->toArray());
+    }
+
+    /** @test */
+    public function it_can_get_the_correct_values_for_find_an_invalid_postal_code()
+    {
+        $address = $this->geonames->setHttpClient(new Client([
+            'handler' => new MockHandler([
+                new Response(200, [], '{"postalcodes":[]}')
+            ]),
+        ]))->find('1234');
+
+        $this->assertInstanceOf(Address::class, $address);
+
+        $this->assertSame([
+            'street' => null,
+            'house_no' => null,
+            'town' => null,
+            'municipality' => null,
+            'province' => null,
+            'latitude' => null,
+            'longitude' => null
+        ], $address->toArray());
+    }
+
+    /** @test */
+    public function it_can_get_the_correct_values_for_find_by_postcode_and_house_number_a_valid_postal_code()
+    {
+         $address = $this->geonames->setHttpClient(new Client([
+            'handler' => new MockHandler([
+                new Response(200, [], '{"postalcodes":[{"adminCode2":"00","adminCode3":"16074","adminName3":"Saale-Holzland-Kreis","adminCode1":"TH","lng":11.5166667,"countryCode":"DE","postalCode":"07751","adminName1":"Thüringen","ISO3166-2":"TH","placeName":"Bucha","lat":50.8833333}]}')
+           ]),
+        ]))->findByPostcodeAndHouseNumber('07751', 'Bucha');
+
+        $this->assertSame('', $this->geonames->getApiKey());
+        $this->assertSame('https://api.geonames.org/postalCodeLookupJSON?postalcode=07751&placename=Bucha&country=DE&username=demo', $this->geonames->getRequestUrl());
+
+        $this->assertInstanceOf(Address::class, $address);
+
+         $this->assertSame([
+            'street' => null,
+            'house_no' => null,
+            'town' => 'Bucha',
+            'municipality' => 'Saale-Holzland-Kreis',
+            'province' => 'Thüringen',
+            'latitude' => 50.8833333,
+            'longitude' => 11.5166667
+        ], $address->toArray());
+    
+    }
+}

--- a/tests/Providers/de_DE/ZippopotamusDE.php
+++ b/tests/Providers/de_DE/ZippopotamusDE.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace nickurt\PostcodeApi\Tests\Providers\de_DE;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use nickurt\PostcodeApi\Entity\Address;
+use nickurt\PostcodeApi\Exception\NotSupportedException;
+use nickurt\PostcodeApi\Providers\de_DE\ZippopotamusDE;
+use nickurt\PostcodeApi\Tests\Providers\BaseProviderTest;
+
+class ZippopotamusDETest extends BaseProviderTest
+{
+    /** @var zippo */
+    protected $zippo;
+
+    public function setUp(): void
+    {
+        $this->zippo = (new ZippopotamusDE)
+            ->setRequestUrl('https://http://api.zippopotam.us/de/%s')
+            ->setApiKey('');
+    }
+
+    /** @test */
+    public function it_can_get_the_default_config_values_for_this_provider()
+    {
+        $this->assertSame('', $this->zippo->getApiKey());
+        $this->assertSame('https://http://api.zippopotam.us/de/%s', $this->zippo->getRequestUrl());
+    }
+
+    /** @test */
+    public function it_can_get_the_correct_values_for_find_a_valid_postal_code()
+    {
+        $address = $this->zippo->setHttpClient(new Client([
+            'handler' => new MockHandler([
+                new Response(200, [], '{"post code": "07751", "country": "Germany", "country abbreviation": "DE", "places": [ {"place name": "Bucha", "longitude": "11.5167", "state": "Th\u00fcringen", "state abbreviation": "TH", "latitude": "50.8833"} ]} ')
+            ]),
+        ]))->find('07751');
+
+        $this->assertSame('', $this->zippo->getApiKey());
+        $this->assertSame('https://http://api.zippopotam.us/de/07751', $this->zippo->getRequestUrl());
+
+        $this->assertInstanceOf(Address::class, $address);
+
+        $this->assertSame([
+            'street' => null,
+            'house_no' => null,
+            'town' => 'Bucha',
+            'municipality' => null,
+            'province' => 'Thüringen',
+            'latitude' => 50.8833,
+            'longitude' => 11.5167
+        ], $address->toArray());
+    }
+
+    /** @test */
+    public function it_can_get_the_correct_values_for_find_an_invalid_postal_code()
+    {
+        $address = $this->zippo->setHttpClient(new Client([
+            'handler' => new MockHandler([
+                new Response(200, [], '{}')
+            ]),
+        ]))->find('1234');
+
+        $this->assertInstanceOf(Address::class, $address);
+
+        $this->assertSame([
+            'street' => null,
+            'house_no' => null,
+            'town' => null,
+            'municipality' => null,
+            'province' => null,
+            'latitude' => null,
+            'longitude' => null
+        ], $address->toArray());
+    }
+
+    /** @test */
+    public function it_can_get_the_correct_values_for_find_by_postcode_and_house_number_a_valid_postal_code()
+    {
+        $this->expectException(NotSupportedException::class);
+
+        $this->zippo->findByPostcodeAndHouseNumber('1000', '1');
+    }
+}


### PR DESCRIPTION
Two providers have been added to find places for postal codes. They are Zippopotam.us and Geonames.org. Geonames however show a more reliable database