### PR TITLE
Allow null value for long/latitude

### DIFF
--- a/src/Entity/Address.php
+++ b/src/Entity/Address.php
@@ -123,10 +123,10 @@ class Address implements Arrayable
     }
 
     /**
-     * @param float $latitude
+     * @param float|null $latitude
      * @return $this
      */
-    public function setLatitude(float $latitude)
+    public function setLatitude(?float $latitude = null)
     {
         $this->latitude = $latitude;
 
@@ -142,10 +142,10 @@ class Address implements Arrayable
     }
 
     /**
-     * @param float $longitude
+     * @param float|null $longitude
      * @return $this
      */
-    public function setLongitude(float $longitude)
+    public function setLongitude(?float $longitude = null)
     {
         $this->longitude = $longitude;
 


### PR DESCRIPTION
Allow null value for longitude & latitude. 

Not every response for PostcodeNL contains these elements, as the provider PostcodeNL sets the address entity without checking for a valid float value an exception is thrown for a 'valid address' (for instance a postbus result).

Eg:
Zipcode: 1000AA
HouseNumber: 1

Result from postcode.nl: 
```json
{
   "street":"Postbus",
   "houseNumber":1,
   "houseNumberAddition":"",
   "postcode":"1000AA",
   "city":"Amsterdam",
   "municipality":"Amsterdam",
   "province":"Noord-Holland",
   "rdX":null,
   "rdY":null,
   "latitude":null,
   "longitude":null,
   "bagNumberDesignationId":null,
   "bagAddressableObjectId":null,
   "addressType":"PO box",
   "purposes":null,
   "surfaceArea":null,
   "houseNumberAdditions":[
      ""
   ]
}
``` 
Will trigger a TypeError Exception:

```php
TypeError: nickurt\PostcodeApi\Entity\Address::setLatitude(): Argument #1 ($latitude) must be of type float, null given, called in /var/www/html/vendor/nickurt/laravel-postcodeapi/src/Providers/nl_NL/PostcodeNL.php on line 53 and defined in /var/www/html/vendor/nickurt/laravel-postcodeapi/src/Entity/Address.php:129
```

