### PR TITLE
Add url variable to MalformedURLException for debugging

### DIFF
--- a/src/Providers/Provider.php
+++ b/src/Providers/Provider.php
@@ -110,7 +110,7 @@ abstract class Provider implements ProviderInterface
     public function setRequestUrl($url)
     {
         if (filter_var($url, FILTER_VALIDATE_URL) === false) {
-            throw new MalformedURLException();
+            throw new MalformedURLException($url);
         }
 
         $this->requestUrl = $url;


### PR DESCRIPTION
Application periodically throws MalformedURLException even though  the URL is defined in the config. Adding the URL to the exception might help find the problem.