### PR TITLE
Allow laravel 9.x (And small readme fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ $postCode40 = PostcodeApi::create('Pstcd')->findByPostcodeAndHouseNumber('1118CP
 Route::get('/{postCode}', function($postCode) {
     $postCode41 = PostcodeApi::create('PostcodeApiNu')->find($postCode);
     
-    return Response::json($postCode25->toArray(), 200, [], JSON_PRETTY_PRINT);
+    return Response::json($postCode41->toArray(), 200, [], JSON_PRETTY_PRINT);
 });
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "nickurt/laravel-postcodeapi",
-  "description": "Universal PostcodeApi for Laravel 8.x",
+  "description": "Universal PostcodeApi for Laravel 8.x & 9.x",
   "keywords": [
     "postcodeapi",
     "postcode",
@@ -11,7 +11,7 @@
   "license": "MIT",
   "require": {
     "php": "^8.0",
-    "laravel/framework": "^8.0",
+    "laravel/framework": "^8.0|^9.0",
     "guzzlehttp/guzzle": "^7.0.1",
     "ext-json": "*"
   },


### PR DESCRIPTION
Tested this on a clean install of Laravel 9 with the PostcodeApiNu provider. Didn't have keys for the other ones but it Should be fine :)

Also noticed a small variable mistake in the Readme example.